### PR TITLE
tableau and power bi with dagster

### DIFF
--- a/orchestration/pipeline_nsw_doe_requires_secrets/temp_tableau_power_bi.py
+++ b/orchestration/pipeline_nsw_doe_requires_secrets/temp_tableau_power_bi.py
@@ -1,0 +1,33 @@
+import os
+from dagster_tableau import (
+    TableauCloudWorkspace,
+    # build_tableau_materializable_assets_definition, # waiting on dagster 1.9.0
+    # load_tableau_asset_specs,   # waiting on dagster 1.9.0
+    # parse_tableau_external_and_materializable_asset_specs,  # waiting on dagster 1.9.0
+)
+
+# from ... import power_bi_resource
+
+
+# power_bi_resource.build_defs(enable_refresh_semantic_models=True)
+
+
+# Connect to Tableau Cloud using the connected app credentials
+tableau_workspace = TableauCloudWorkspace(
+    connected_app_client_id=os.getenv("TABLEAU_CONNECTED_APP_CLIENT_ID", ""),
+    connected_app_secret_id=os.getenv("TABLEAU_CONNECTED_APP_SECRET_ID", ""),
+    connected_app_secret_value=os.getenv("TABLEAU_CONNECTED_APP_SECRET_VALUE", ""),
+    username=os.getenv("TABLEAU_USERNAME", ""),
+    site_name=os.getenv("TABLEAU_SITE_NAME", ""),
+    pod_name=os.getenv("TABLEAU_POD_NAME", ""),
+)
+
+
+# # power_bi_resource = PowerBIWorkspace(
+# #     credentials=PowerBIServicePrincipal(
+# #         client_id=os.getenv("POWER_BI_CLIENT_ID",""),
+# #         client_secret=os.getenv("POWER_BI_CLIENT_SECRET",""),
+# #         tenant_id=os.getenv("POWER_BI_TENANT_ID",""),
+# #     ),
+# #     workspace_id=os.getenv("POWER_BI_WORKSPACE_ID",""),
+# # )

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,8 @@ duckdb==1.1.1 #latest version for mother duck
 
 # dagster deps
 dagster
+dagster-powerbi
+dagster-tableau
 dagster-dbt
 dagster-duckdb
 dagster-duckdb-pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,8 @@ aioitertools==0.12.0
     # via aiobotocore
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.13.3
+alembic==1.14.0
     # via dagster
-aniso8601==9.0.1
-    # via graphene
 ansicolors==1.1.8
     # via papermill
 anyio==4.6.2.post1
@@ -56,18 +54,18 @@ bitmath==1.3.3.1
     # via noteable-origami
 black==24.10.0
     # via pandera
-bleach==6.1.0
+bleach==6.2.0
     # via nbconvert
 boto3==1.35.36
     # via dagster-aws
-boto3-stubs-lite==1.35.43
+boto3-stubs-lite==1.35.58
     # via dagster-aws
 botocore==1.35.36
     # via
     #   aiobotocore
     #   boto3
     #   s3transfer
-botocore-stubs==1.35.43
+botocore-stubs==1.35.58
     # via boto3-stubs-lite
 cachetools==5.5.0
     # via google-auth
@@ -119,9 +117,9 @@ comm==0.2.2
     #   ipywidgets
 contourpy==1.3.0
     # via matplotlib
-croniter==3.0.3
+croniter==5.0.1
     # via dagster
-cryptography==43.0.1
+cryptography==43.0.3
     # via
     #   jwt
     #   noteable-origami
@@ -132,7 +130,7 @@ dacite==1.8.1
     # via ydata-profiling
 daff==1.3.46
     # via dbt-core
-dagster==1.8.12
+dagster==1.8.13
     # via
     #   dagster-aws
     #   dagster-cloud
@@ -145,37 +143,41 @@ dagster==1.8.12
     #   dagster-msteams
     #   dagster-openai
     #   dagster-pandera
+    #   dagster-powerbi
+    #   dagster-tableau
     #   dagster-webserver
     #   dagstermill
-dagster-aws==0.24.12
-dagster-cloud==1.8.12
-dagster-cloud-cli==1.8.12
+dagster-aws==0.24.13
+dagster-cloud==1.8.13
+dagster-cloud-cli==1.8.13
     # via dagster-cloud
-dagster-dbt==0.24.12
-dagster-duckdb==0.24.12
+dagster-dbt==0.24.13
+dagster-duckdb==0.24.13
     # via dagster-duckdb-pandas
-dagster-duckdb-pandas==0.24.12
-dagster-embedded-elt==0.24.12
-dagster-graphql==1.8.12
+dagster-duckdb-pandas==0.24.13
+dagster-embedded-elt==0.24.13
+dagster-graphql==1.8.13
     # via dagster-webserver
-dagster-msteams==0.24.12
-dagster-openai==0.24.12
-dagster-pandera==0.24.12
-dagster-pipes==1.8.12
+dagster-msteams==0.24.13
+dagster-openai==0.24.13
+dagster-pandera==0.24.13
+dagster-pipes==1.8.13
     # via dagster
-dagster-webserver==1.8.12
-dagstermill==0.24.12
+dagster-powerbi==0.0.12
+dagster-tableau==0.0.2
+dagster-webserver==1.8.13
+dagstermill==0.24.13
 dataclasses-json==0.6.7
     # via
     #   langchain
     #   langchain-community
-dbt-adapters==1.7.0
+dbt-adapters==1.11.0
     # via
     #   dbt-core
     #   dbt-duckdb
 dbt-artifacts-parser==0.6.0
     # via dbterd
-dbt-common==1.11.0
+dbt-common==1.12.0
     # via
     #   dbt-adapters
     #   dbt-core
@@ -196,14 +198,16 @@ dbt-semantic-interfaces==0.5.1
     #   dbt-metricflow
     #   metricflow
 dbterd==1.18.0
-debugpy==1.8.7
+debugpy==1.8.8
     # via ipykernel
 decorator==5.1.1
     # via ipython
 deepdiff==7.0.1
     # via dbt-common
 defusedxml==0.7.1
-    # via nbconvert
+    # via
+    #   nbconvert
+    #   tableauserverclient
 diff-cover==9.2.0
     # via sqlfluff
 diff-match-patch==20200713
@@ -212,7 +216,7 @@ distlib==0.3.9
     # via virtualenv
 distro==1.9.0
     # via openai
-dlt==1.2.0
+dlt==1.3.0
     # via dagster-embedded-elt
 docstring-parser==0.16
     # via dagster
@@ -224,7 +228,7 @@ entrypoints==0.4
     # via
     #   jupyter-client
     #   papermill
-et-xmlfile==1.1.0
+et-xmlfile==2.0.0
     # via openpyxl
 executing==2.1.0
     # via stack-data
@@ -239,11 +243,11 @@ fonttools==4.54.1
     # via matplotlib
 frictionless==4.40.8
     # via pandera
-frozenlist==1.4.1
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.9.0
+fsspec==2024.10.0
     # via
     #   dlt
     #   s3fs
@@ -256,13 +260,13 @@ gitpython==3.1.43
     # via dlt
 giturlparse==0.12.0
     # via dlt
-google-analytics-data==0.18.12
-google-api-core==2.21.0
+google-analytics-data==0.18.15
+google-api-core==2.23.0
     # via
     #   google-analytics-data
     #   google-api-python-client
-google-api-python-client==2.149.0
-google-auth==2.35.0
+google-api-python-client==2.151.0
+google-auth==2.36.0
     # via
     #   google-analytics-data
     #   google-api-core
@@ -278,7 +282,7 @@ googleapis-common-protos==1.65.0
     #   grpcio-status
 gql==3.5.0
     # via dagster-graphql
-graphene==3.3
+graphene==3.4.3
     # via dagster-graphql
 graphql-core==3.2.5
     # via
@@ -291,7 +295,7 @@ graphviz==0.20.3
     # via metricflow
 greenlet==3.1.1
     # via sqlalchemy
-grpcio==1.67.0
+grpcio==1.67.1
     # via
     #   dagster
     #   google-api-core
@@ -309,7 +313,7 @@ halo==0.0.31
     # via dbt-metricflow
 hexbytes==1.2.1
     # via dlt
-holidays==0.58
+holidays==0.60
     # via prophet
 htmlmin==0.1.12
     # via ydata-profiling
@@ -330,7 +334,7 @@ humanfriendly==10.0
     # via coloredlogs
 humanize==4.11.0
     # via dlt
-identify==2.6.1
+identify==2.6.2
     # via pre-commit
 idna==3.10
     # via
@@ -350,7 +354,7 @@ iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
     # via dagstermill
-ipython==8.28.0
+ipython==8.29.0
     # via
     #   ipykernel
     #   ipywidgets
@@ -363,7 +367,7 @@ isodate==0.6.1
     #   agate
     #   dbt-common
     #   frictionless
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via
@@ -382,7 +386,7 @@ jinja2==3.1.4
     #   ydata-profiling
 jinja2-simple-tags==0.6.1
     # via sqlfluff-templater-dbt
-jiter==0.6.1
+jiter==0.7.0
     # via openai
 jmespath==1.0.1
     # via
@@ -432,14 +436,14 @@ kiwisolver==1.4.7
 langchain==0.1.11
 langchain-community==0.0.38
     # via langchain
-langchain-core==0.1.52
+langchain-core==0.1.53
     # via
     #   langchain
     #   langchain-community
     #   langchain-text-splitters
 langchain-text-splitters==0.0.2
     # via langchain
-langsmith==0.1.136
+langsmith==0.1.142
     # via
     #   langchain
     #   langchain-community
@@ -454,20 +458,20 @@ logbook==1.5.3
     # via dbt-core
 makefun==1.15.6
     # via dlt
-mako==1.3.5
+mako==1.3.6
     # via alembic
 markdown-it-py==3.0.0
     # via rich
 marko==2.1.2
     # via frictionless
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via
     #   jinja2
     #   mako
     #   nbconvert
-marshmallow==3.23.0
+marshmallow==3.23.1
     # via dataclasses-json
-mashumaro==3.13.1
+mashumaro==3.14
     # via
     #   dbt-adapters
     #   dbt-common
@@ -506,13 +510,13 @@ multimethod==1.10
     #   pandera
     #   visions
     #   ydata-profiling
-mypy-boto3-ecs==1.35.43
+mypy-boto3-ecs==1.35.52
     # via boto3-stubs-lite
 mypy-boto3-emr==1.35.39
     # via boto3-stubs-lite
 mypy-boto3-emr-serverless==1.35.25
     # via boto3-stubs-lite
-mypy-boto3-glue==1.35.25
+mypy-boto3-glue==1.35.53
     # via boto3-stubs-lite
 mypy-extensions==1.0.0
     # via
@@ -534,7 +538,7 @@ nest-asyncio==1.6.0
     # via
     #   ipykernel
     #   jupyter-client
-networkx==3.4.1
+networkx==3.4.2
     # via
     #   dagster-dbt
     #   dbt-core
@@ -560,7 +564,6 @@ numpy==1.25.2
     #   patsy
     #   phik
     #   prophet
-    #   pyarrow
     #   pywavelets
     #   scikit-learn
     #   scipy
@@ -572,12 +575,12 @@ numpy==1.25.2
     #   ydata-profiling
 oauthlib==3.2.2
     # via requests-oauthlib
-openai==1.52.0
+openai==1.54.3
     # via dagster-openai
 openpyxl==3.1.5
 ordered-set==4.1.0
     # via deepdiff
-orjson==3.10.7
+orjson==3.10.11
     # via
     #   dagster-dbt
     #   dlt
@@ -604,6 +607,7 @@ packaging==23.2
     #   pytest
     #   requirements-parser
     #   statsmodels
+    #   tableauserverclient
 pandas==2.0.3
     # via
     #   cmdstanpy
@@ -639,13 +643,13 @@ pathspec==0.12.1
     #   sqlfluff
 pathvalidate==3.2.1
     # via dlt
-patsy==0.5.6
+patsy==1.0.0
     # via statsmodels
 pendulum==3.0.0
     # via dlt
 petl==1.7.15
     # via frictionless
-pex==2.20.3
+pex==2.24.1
     # via dagster-cloud
 pexpect==4.9.0
     # via ipython
@@ -666,6 +670,7 @@ plotly==5.24.1
 pluggy==1.5.0
     # via
     #   diff-cover
+    #   dlt
     #   pytest
 ply==3.11
     # via jsonpath-ng
@@ -677,7 +682,7 @@ prompt-toolkit==3.0.48
 propcache==0.2.0
     # via yarl
 prophet==1.1.6
-proto-plus==1.24.0
+proto-plus==1.25.0
     # via
     #   google-analytics-data
     #   google-api-core
@@ -699,7 +704,7 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
-pyarrow==17.0.0
+pyarrow==18.0.0
     # via scrapbook
 pyasn1==0.6.1
     # via
@@ -709,7 +714,7 @@ pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
-pydantic==1.10.18
+pydantic==1.10.19
     # via
     #   dagster
     #   dbt-artifacts-parser
@@ -729,7 +734,9 @@ pygments==2.18.0
     #   nbconvert
     #   rich
 pyjwt==2.9.0
-    # via github3-py
+    # via
+    #   dagster-tableau
+    #   github3-py
 pyparsing==3.2.0
     # via
     #   httplib2
@@ -744,6 +751,7 @@ python-dateutil==2.9.0.post0
     #   dbt-semantic-interfaces
     #   frictionless
     #   github3-py
+    #   graphene
     #   holidays
     #   jupyter-client
     #   matplotlib
@@ -796,13 +804,13 @@ questionary==1.10.0
     # via
     #   dagster-cloud
     #   dagster-cloud-cli
-rapidfuzz==3.10.0
+rapidfuzz==3.10.1
     # via metricflow
 referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.9.11
+regex==2024.11.6
     # via
     #   sqlfluff
     #   tiktoken
@@ -830,6 +838,7 @@ requests==2.32.3
     #   papermill
     #   requests-oauthlib
     #   requests-toolbelt
+    #   tableauserverclient
     #   tiktoken
     #   update-checker
     #   ydata-profiling
@@ -843,19 +852,19 @@ requirements-parser==0.11.0
     # via dlt
 rfc3986==2.0.0
     # via frictionless
-rich==13.9.2
+rich==13.9.4
     # via
     #   dagster
     #   dagster-dbt
     #   typer
-rpds-py==0.20.0
+rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
 rsa==4.9
     # via google-auth
-ruff==0.7.0
-s3fs==2024.9.0
+ruff==0.7.3
+s3fs==2024.10.0
 s3transfer==0.10.3
     # via boto3
 scikit-learn==1.5.2
@@ -874,13 +883,13 @@ semver==3.0.2
     # via dlt
 sending==0.3.0
     # via noteable-origami
-setuptools==75.2.0
+setuptools==75.4.0
     # via
     #   dagster
     #   dlt
 shellingham==1.5.4
     # via typer
-simpleeval==1.0.0
+simpleeval==1.0.3
     # via frictionless
 simplejson==3.19.3
     # via dlt
@@ -888,15 +897,13 @@ six==1.16.0
     # via
     #   asttokens
     #   astunparse
-    #   bleach
     #   halo
     #   isodate
     #   minimal-snowplow-tracker
-    #   patsy
     #   python-dateutil
-sling==1.2.20
+sling==1.2.22
     # via dagster-embedded-elt
-sling-linux-amd64==1.2.20
+sling-linux-amd64==1.2.22
     # via sling
 smmap==5.0.1
     # via gitdb
@@ -915,12 +922,12 @@ sqlalchemy==2.0.36
     #   dagster
     #   langchain
     #   langchain-community
-sqlfluff==3.2.4
+sqlfluff==3.2.5
     # via sqlfluff-templater-dbt
-sqlfluff-templater-dbt==3.2.4
-sqlglot==25.25.1
+sqlfluff-templater-dbt==3.2.5
+sqlglot==25.30.0
     # via dagster-dbt
-sqlglotrs==0.2.12
+sqlglotrs==0.2.13
     # via sqlglot
 sqlparse==0.5.1
     # via dbt-core
@@ -928,7 +935,7 @@ stack-data==0.6.3
     # via ipython
 stanio==0.5.1
     # via cmdstanpy
-starlette==0.41.0
+starlette==0.41.2
     # via
     #   dagster-graphql
     #   dagster-webserver
@@ -940,6 +947,8 @@ structlog==22.3.0
     # via
     #   dagster
     #   noteable-origami
+tableauserverclient==0.34
+    # via dagster-tableau
 tabulate==0.9.0
     # via
     #   dagster
@@ -966,9 +975,9 @@ threadpoolctl==3.5.0
 tiktoken==0.8.0
 time-machine==2.16.0
     # via pendulum
-tinycss2==1.3.0
+tinycss2==1.4.0
     # via nbconvert
-tomli==2.0.2
+tomli==2.1.0
     # via dagster
 tomlkit==0.13.2
     # via dlt
@@ -978,7 +987,7 @@ tornado==6.4.1
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.66.5
+tqdm==4.67.0
     # via
     #   cmdstanpy
     #   dagster
@@ -999,21 +1008,21 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-typeguard==4.3.0
+typeguard==4.4.1
     # via
     #   pandera
     #   ydata-profiling
-typer==0.12.5
+typer==0.13.0
     # via
     #   dagster-cloud
     #   dagster-cloud-cli
     #   dagster-dbt
     #   frictionless
-types-awscrt==0.22.0
+types-awscrt==0.23.0
     # via botocore-stubs
 types-s3transfer==0.10.3
     # via boto3-stubs-lite
-types-setuptools==75.1.0.20241014
+types-setuptools==75.3.0.20241112
     # via requirements-parser
 typing-extensions==4.12.2
     # via
@@ -1025,6 +1034,7 @@ typing-extensions==4.12.2
     #   dbt-core
     #   dbt-semantic-interfaces
     #   dlt
+    #   graphene
     #   ipython
     #   mashumaro
     #   metricflow
@@ -1035,6 +1045,7 @@ typing-extensions==4.12.2
     #   openai
     #   pydantic
     #   sqlalchemy
+    #   tableauserverclient
     #   typeguard
     #   typer
     #   typing-inspect
@@ -1059,13 +1070,14 @@ urllib3==2.2.3
     # via
     #   botocore
     #   requests
+    #   tableauserverclient
 uvicorn==0.32.0
     # via dagster-webserver
 uvloop==0.21.0
     # via uvicorn
 validators==0.34.0
     # via frictionless
-virtualenv==20.26.6
+virtualenv==20.27.1
     # via pre-commit
 visions==0.7.5
     # via ydata-profiling
@@ -1079,24 +1091,24 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websockets==13.1
+websockets==14.0
     # via
     #   noteable-origami
     #   uvicorn
-wheel==0.44.0
+wheel==0.45.0
     # via astunparse
 widgetsnbextension==4.0.13
     # via ipywidgets
-wordcloud==1.9.3
+wordcloud==1.9.4
     # via ydata-profiling
 wrapt==1.16.0
     # via
     #   aiobotocore
     #   pandera
-yarl==1.15.4
+yarl==1.17.1
     # via
     #   aiohttp
     #   gql
 ydata-profiling==4.6.0
-zipp==3.20.2
+zipp==3.21.0
     # via importlib-metadata


### PR DESCRIPTION
# tableau

tableau working for just reports. need to wait for 1.9 for data sets. dagster 1.9 cant move till until metricflow supports 2.x for pydatnic. Latest metricflow using is 0.206 released in june-24 inly support 1.x. But can see they have changed it in the main branch:

https://github.com/dbt-labs/metricflow/blob/668c5f8e7821e249d89fe0befec807590b769c86/extra-hatch-configuration/requirements.txt#L4

# power BI
The error message contains extra url (**groups/8317eb5c-da79-4bc3-a756-66bb2589598d**) when compared to the docs on Microsoft
HTTPError: 404 Client Error: Not Found for url: https://api.powerbi.com/v1.0/myorg/groups/8317eb5c-da79-4bc3-a756-66bb2589598d/datasets/55e53383-6f62-425c-a40c-12342bd2f7b2/datasources

https://app.powerbi.com/groups/8317eb5c-da79-4bc3-a756-66bb2589598d/datasets/55e53383-6f62-425c-a40c-12342bd2f7b2/details?experience=power-bi

this works

https://api.powerbi.com/v1.0/myorg/datasets/55e53383-6f62-425c-a40c-12342bd2f7b2/datasources

did it with the https://learn.microsoft.com/en-us/rest/api/power-bi/datasets/get-datasources#code-try-0

docs:

<img width="935" alt="image" src="https://github.com/user-attachments/assets/1b0bdb19-5cf1-405b-97bb-9dcedd28ef9a">

debugging looks like this group_scoped condition is causing the issue:

<img width="839" alt="image" src="https://github.com/user-attachments/assets/fb79f57a-64df-4331-9844-0feb5c0d5ea2">



Also note it looks like there is a issue with 1.9 too: https://github.com/dagster-io/dagster/issues/25803